### PR TITLE
fix: poolpi review

### DIFF
--- a/contracts/OTCTrader.sol
+++ b/contracts/OTCTrader.sol
@@ -6,7 +6,6 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import {SafeERC20, SafeMath, IERC20, Address} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/Math.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 //contract to swap woofy for yfi. 1-1
@@ -15,8 +14,8 @@ contract OTCTrader is Ownable {
     using Address for address;
     using SafeMath for uint256;
 
-    address public yfi = address(0x29b0Da86e484E1C0029B56e817912d778aC0EC69);
-    address public woofy = address(0xD0660cD418a64a1d44E9214ad8e459324D8157f1);
+    address internal constant yfi = 0x29b0Da86e484E1C0029B56e817912d778aC0EC69;
+    address internal constant woofy = 0xD0660cD418a64a1d44E9214ad8e459324D8157f1;
     mapping(address => uint256) public deposits; // amount of liquidity user has provided
     mapping(address => bool) public traders; // allow us to limit traders
 
@@ -78,7 +77,7 @@ contract OTCTrader is Ownable {
 
         uint256 balanceBefore = token.balanceOf(address(this));
 
-        require(balanceBefore >= _amount, "not enough liquidty");
+        require(balanceBefore >= _amount, "not enough liquidity");
         uint256 deposited = deposits[msg.sender];
         require(deposited >= _amount, "not enough deposits");
 

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -92,8 +92,7 @@ contract Strategy is BaseStrategy {
     bool public tradesEnabled;
     bool public realiseLosses;
     bool public depositerAvoid;
-    address public tradeFactory =
-        address(0xD3f89C21719Ec5961a3E6B0f9bBf9F9b4180E9e9);
+    address public tradeFactory = 0xD3f89C21719Ec5961a3E6B0f9bBf9F9b4180E9e9; // Lost in a clone
 
     IERC20 internal constant yfi =
         IERC20(0x29b0Da86e484E1C0029B56e817912d778aC0EC69);
@@ -105,14 +104,13 @@ contract Strategy is BaseStrategy {
     IERC20 internal constant solid =
         IERC20(0x888EF71766ca594DED1F0FA3AE64eD2941740A20);
 
-    uint256 public lpSlippage = 995; //0.5% slippage allowance
+    uint256 public lpSlippage = 995; //0.5% slippage allowance // lost in a clone
 
     string internal stratName; // we use this for our strategy's name on cloning
-    address public lpToken =
-        address(0x4b3a172283ecB7d07AB881a9443d38cB1c98F4d0); //var yfi/woofy
-    ILpDepositer public lpDepositer =
+    address public lpToken = 0x4b3a172283ecB7d07AB881a9443d38cB1c98F4d0; //var yfi/woofy // This will disappear in a clone!
+    ILpDepositer internal constant lpDepositer =
         ILpDepositer(0x26E1A0d851CF28E697870e1b7F053B605C8b060F);
-    uint256 dustThreshold = 1e14;
+    uint256 dustThreshold = 1e14; // review: Several variables will be gone in a clone.
 
     bool internal forceHarvestTriggerOnce; // only set this to true externally when we want to trigger our keepers to harvest for us
     uint256 public minHarvestCredit; // if we hit this amount of credit, harvest the strategy
@@ -128,6 +126,7 @@ contract Strategy is BaseStrategy {
         address _otcSwapper
     ) public BaseStrategy(_vault) {
         _initializeStrat(_name, _otcSwapper);
+        // Why this is not part of the initialize?
         otcSwapper = IOTCSwapper(_otcSwapper);
     }
 
@@ -135,7 +134,7 @@ contract Strategy is BaseStrategy {
     function _initializeStrat(string memory _name, address _trader) internal {
         // initialize variables
         maxReportDelay = 43200; // 1/2 day in seconds, if we hit this then harvestTrigger = True
-        healthCheck = address(0xf13Cd6887C62B5beC145e30c38c4938c5E627fe0); // Fantom common health check
+        healthCheck = 0xf13Cd6887C62B5beC145e30c38c4938c5E627fe0; // Fantom common health check
 
         // set our strategy's name
         stratName = _name;
@@ -302,7 +301,7 @@ contract Strategy is BaseStrategy {
 
         //if arb is less than fees then no arb
         if(yfiInLp.mul(1_000) > woofyInLp.mul(999) && woofyInLp.mul(1_000) > yfiInLp.mul(999) ){
-            
+
             return (address(yfi), 0);
         }
 
@@ -473,7 +472,7 @@ contract Strategy is BaseStrategy {
         override
         returns (uint256 _liquidatedAmount, uint256 _loss)
     {
-        
+
         uint256 balanceOfYfi = want.balanceOf(address(this));
 
         // if we need more yfi than is already loose in the contract
@@ -527,7 +526,7 @@ contract Strategy is BaseStrategy {
             balanceOfYfi = want.balanceOf(address(this));
             if(balanceOfYfi < _amountNeeded){
                 balanceOfYfi = GetFromOTC(yfi,_amountNeeded - balanceOfYfi );
-            } 
+            }
 
             _liquidatedAmount = Math.min(
                balanceOfYfi,


### PR DESCRIPTION
Some additional comments done in telegram:

**1) you are keeping depositors state in the contract**

remember the hack on popsicle, transferring positions. 
There is no token in your code, but I wonder if transferring stuff breaks logic somewhere.
I guess not but I wanted to raise it

**2) you are not protecting against reentrancy**

usually the transfer goes at the end, after updating the storage, in `withdrawLiquidity()`

instead of 

```
        token.safeTransfer(msg.sender, _amount);
        deposits[msg.sender] = deposited.sub(_amount);
```

do

```
        deposits[msg.sender] = deposited.sub(_amount);
        token.safeTransfer(msg.sender, _amount);
```

**3)  I would remove the possibility of being open**
Specially since you are going to release it fast.

**4) `locked` modifier should be: `tradersOnly`**
Confusing name.

**5) when would you call `_arbThePeg` instead of `tend()`**
Not sure if you need `_arbThePeg()` to be external, having `tend()`.

**6) why are you using - yearn/yearn-vaults@0.4.2-1 ?**

**7) Clone should fail**
There are several instance variables initialized at the field level.
plz revise.